### PR TITLE
Feed content should not be made clickable as feed readers and Micro.blog will handle it.

### DIFF
--- a/includes/PostType.php
+++ b/includes/PostType.php
@@ -65,10 +65,11 @@ final class MicroPosts_PostType
     public static function the_content( $content )
     {
         global $post;
-        if ( self::POST_TYPE == $post->post_type ) {
-          // Make hyperlinks clickable by default.
-          $content = self::make_clickable( $content );
+        if ( ! is_feed() && self::POST_TYPE == $post->post_type && apply_filters( 'micro_posts_make_clickable', true ) ) {
+            // Make hyperlinks clickable by default.
+            $content = self::make_clickable( $content );
         }
+
         return $content;
     }
 


### PR DESCRIPTION
Depends #6 

Because of the previous PR to add micro_posts to the main feed, the built in `make_clickable` function shouldn't be applied to feed content as feed readers and Micro.blog will handle it and process hash-tags appropriately.

Added `micro_posts_make_clickable` filter to allow opting out of making content clickable (e.g. if already using Markdown).